### PR TITLE
extend dummy cmakelists with minimum version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,8 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
+      - id: no-commit-to-branch
+        args: [--branch, main]
 
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 23.12.0

--- a/tests/test_hook/dummy_project/CMakeLists.txt
+++ b/tests/test_hook/dummy_project/CMakeLists.txt
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.16)
+
 project(DummyProject)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)


### PR DESCRIPTION
- resolve cmake warning in dummy project
- add pre-commit-hook to avoid commit to main branch