### PR TITLE
Stop as soon as a compilation database is found

### DIFF
--- a/hook/compilation_database.py
+++ b/hook/compilation_database.py
@@ -19,6 +19,7 @@ class CompilationDatabase:
         for root, dirs, files in os.walk(path):
             if name in files:
                 self.path = os.path.join(root, name)
+                break
 
     def __extract_include_directories(self) -> None:
         if self.path is not None:


### PR DESCRIPTION
I have a project where cmake's build folders are located within the project directory. I am using a script that rewrites those databases and copies them into the root folder. I noticed that the hook uses the compilation database in the build folder.

A simple break in the find function fixes this issue. Apart from the problem described above, it also should improve performance.